### PR TITLE
fix: modified hero section height

### DIFF
--- a/src/components/sections/Main.tsx
+++ b/src/components/sections/Main.tsx
@@ -1,64 +1,63 @@
-import coderumble_white from '@/assets/coderumble_white.svg'
-import tpc_logo from '@/assets/tpc_logo.svg'
-import three from '@/assets/three.svg'
-import Image from 'next/image';
-import PageBeetles from '@/components/PageBeetles';
+import coderumble_white from "@/assets/coderumble_white.svg"
+import tpc_logo from "@/assets/tpc_logo.svg"
+import three from "@/assets/three.svg"
+import Image from "next/image"
+import PageBeetles from "@/components/PageBeetles"
 
 export default function Main() {
-	return (
-		<div className="min-h-screen relative flex flex-col justify-center items-center" id="home">
-			<PageBeetles pageType="main" beetleCount={3} />
-			
-			<div className='gap-10 w-[70%] flex justify-center h-44 mb-14'>
-				<Image
-					className='w-[80%]'
-					src={coderumble_white}
-					alt="Coderumble"
-					priority
-				/>
-				<div className='flex w-[20%] flex-col h-full justify-between px-5'>
-					<div className='bg-white h-7 w-full'></div>
-					<Image
-						className='self-center'
-						src={three}
-						alt="Coderumble"
-						priority
-					/>
-					<div className='bg-white h-7 w-full'></div>
-				</div>
-			</div>
+  return (
+    <div
+      className="min-h-[92vh] relative flex flex-col justify-center items-center"
+      id="home"
+    >
+      <PageBeetles pageType="main" beetleCount={3} />
 
-			<div className="absolute bottom-0 w-full flex flex-col items-center">
-				<div className='mb-4'>
-					<a
-						href="https://docs.google.com/forms/d/e/1FAIpQLSebjJtySWg-EUSD_Hio5OBF-EYOVWA0BatjSxaAzjUnzzj7mg/viewform"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<button className='font-mabry rounded-full text-4xl bg-blue-600 text-lime-400 border-4 border-lime-400 px-12 py-4 hover:bg-blue-700 transition-colors  cursor-pointer'>
-							Register!
-						</button>
-					</a>
-				</div>
+      <div className="gap-10 w-[70%] flex justify-center h-44 mb-14">
+        <Image
+          className="w-[80%]"
+          src={coderumble_white}
+          alt="Coderumble"
+          priority
+        />
+        <div className="flex w-[20%] flex-col h-full justify-between px-5">
+          <div className="bg-white h-7 w-full"></div>
+          <Image
+            className="self-center"
+            src={three}
+            alt="Coderumble"
+            priority
+          />
+          <div className="bg-white h-7 w-full"></div>
+        </div>
+      </div>
 
-				<div className="w-full grid grid-cols-3 items-center h-fit px-18 py-5">
-					<div className="flex justify-start">
-						<Image
-							src={tpc_logo}
-							alt="TPC Logo"
-							className="h-16"
-						/>
-					</div>
+      <div className="absolute bottom-0 w-full flex flex-col items-center">
+        <div className="mb-4">
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLSebjJtySWg-EUSD_Hio5OBF-EYOVWA0BatjSxaAzjUnzzj7mg/viewform"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <button className="font-mabry rounded-full text-4xl bg-blue-600 text-lime-400 border-4 border-lime-400 px-12 py-4 hover:bg-blue-700 transition-colors  cursor-pointer">
+              Register!
+            </button>
+          </a>
+        </div>
 
-					<div className="text-white text-center">
-						<div className="text-lg font-bold">Date</div>
-					</div>
+        <div className="w-full grid grid-cols-3 items-center h-fit px-18 py-5">
+          <div className="flex justify-start">
+            <Image src={tpc_logo} alt="TPC Logo" className="h-16" />
+          </div>
 
-					<div className="text-white flex justify-end pr-2">
-						<div className="text-lg font-bold">socials</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	);
+          <div className="text-white text-center">
+            <div className="text-lg font-bold">Date</div>
+          </div>
+
+          <div className="text-white flex justify-end pr-2">
+            <div className="text-lg font-bold">socials</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }


### PR DESCRIPTION
This pull request makes minor improvements to the `Main` section component, primarily focusing on code style consistency and minor UI adjustments.

* Code style improvements:
  * Updated all import statements to use double quotes for consistency.
  * Reformatted JSX code to use consistent indentation and spacing, improving readability. [[1]](diffhunk://#diff-a2cccdc42919f9793e49765a481a29967d77e9774fa22ec07566b3ee9eecfaa9L1-R49) [[2]](diffhunk://#diff-a2cccdc42919f9793e49765a481a29967d77e9774fa22ec07566b3ee9eecfaa9L63-R62)

* UI adjustments:
  * Changed the main container's minimum height from `min-h-screen` to `min-h-[92vh]` for better layout control.