### PR TITLE
chore: fixed svg to gif transition bug

### DIFF
--- a/src/components/PageBeetles.tsx
+++ b/src/components/PageBeetles.tsx
@@ -162,7 +162,11 @@ const PageBeetles = ({ pageType, beetleCount = 3 }: PageBeetlesProps) => {
               alt={beetle.isFlying ? "Flying Beetle" : "Static Beetle"}
               width={100}
               height={100}
-              className="w-25 h-25" // Fixed size: 100px x 100px
+              className={
+                beetle.isFlying
+                  ? "scale-[250%] rotate-45 duration-500"
+                  : "w-25 h-25"
+              }
               style={{
                 width: "100px",
                 height: "100px",


### PR DESCRIPTION
This pull request updates the appearance of beetle images in the `PageBeetles` component to visually distinguish flying beetles from static ones. The main change is the dynamic application of CSS classes based on the beetle's state.

**UI improvements:**

* In `src/components/PageBeetles.tsx`, the `className` for each beetle image now conditionally applies `"scale-[250%] rotate-45 duration-500"` for flying beetles, making them larger and rotated, while static beetles retain the fixed size classes `"w-25 h-25"`.